### PR TITLE
rails_example_group: don't include RSpec::Rails::FixtureSupport if it's not defined

### DIFF
--- a/lib/rspec/rails/example/rails_example_group.rb
+++ b/lib/rspec/rails/example/rails_example_group.rb
@@ -11,7 +11,7 @@ module RSpec
       include RSpec::Rails::MinitestLifecycleAdapter if ::Rails::VERSION::STRING >= '4'
       include RSpec::Rails::MinitestAssertionAdapter
       include RSpec::Rails::Matchers
-      include RSpec::Rails::FixtureSupport
+      include RSpec::Rails::FixtureSupport if RSpec::Rails::FixtureSupport rescue false 
     end
   end
 end


### PR DESCRIPTION
If ActiveRecord::Fixtures aren't defined, then the line <code>include RSpec::Rails::FixtureSupport</code> in
<code>rspec/rails/example/rails_example_group</code> throws an error.

I found this when I started to use the ammeter gem to help me write a spec for a generator.
The ammeter gem <code>requires 'rspec/rails/example/rails_example_group'</code> which has the line <code>include RSpec::Rails::FixtureSupport</code>.

#1372 introduced a conditional around the definition for RSpec::Rails::FixtureSupport (in <code>rspec/rails/fixture_support.rb</code>) so that the class is not defined if ActiveRecord::TestFixtures isn't defined.  So when the <code>include RSpec::Rails::FixtureSupport</code> line in <code>rspec/rails/example/rails_example_group</code> is evaluated, an error is thrown since RSpec::Rails::FixtureSupport was never defined.  This include line needs a conditional to check for this situation.  I tested this correction: <code>include RSpec::Rails::FixtureSupport if RSpec::Rails::FixtureSupport rescue false</code> and it works.

Here's the environment and generator spec test file that shows the error:
  Ruby 2.1.5p273
  Rails 4.2.1
  rspec (3.3.0)
  rspec-rails (3.3.2)  [I also tested master; same error occurs, same fix works]
  ammeter (1.1.2)

spec_helper.rb and rails_helper.rb have defaults. No modifications were made to the originally installed files.

Generator spec test file:
   ```
   #  runs successfully with this line changed in rspec/rails/example/rails_example_group:
   #    original line: include RSpec::Rails::FixtureSupport if RSpec::Rails::FixtureSupport
   #    revised line:  include RSpec::Rails::FixtureSupport if RSpec::Rails::FixtureSupport rescue false # AE 2015-06-24
   require 'rails_helper'

   class RspecRailsFixturesBugGenEx < Rails::Generators::NamedBase
     def generate_stuff
     end
     def generate_nonsense
     end
   end

   describe RspecRailsFixturesBugGenEx do
     # Tell the generator where to put its output (
     destination File.expand_path("../../../../../tmp", __FILE__)
     before { prepare_destination }
     it 'runs all tasks in the generator' do
       gen = generator %w(posts)
       gen.should_receive :generate_stuff
       gen.should_receive :generate_nonsense
       gen.invoke_all
     end
   end
   ```

Stack trace with the error:
(I'm using RubyMine so a bit of that cruft is in the trace output.)
```
C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-rails-1fb6f9f642e8/lib/rspec/rails/example/rails_example_group.rb:14:in `<module:RailsExampleGroup>': uninitialized constant RSpec::Rails::FixtureSupport (NameError)
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-rails-1fb6f9f642e8/lib/rspec/rails/example/rails_example_group.rb:8:in `<module:Rails>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-rails-1fb6f9f642e8/lib/rspec/rails/example/rails_example_group.rb:6:in `<module:RSpec>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-rails-1fb6f9f642e8/lib/rspec/rails/example/rails_example_group.rb:5:in `<top (required)>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/ammeter-1.1.2/lib/ammeter/rspec/generator/example/generator_example_group.rb:4:in `<top (required)>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/ammeter-1.1.2/lib/ammeter/rspec/generator/example.rb:2:in `<top (required)>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/ammeter-1.1.2/lib/ammeter/init.rb:7:in `<top (required)>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/ammeter-1.1.2/lib/ammeter/railtie.rb:4:in `block in <class:Railtie>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/railties-4.2.1/lib/rails/initializable.rb:30:in `instance_exec'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/railties-4.2.1/lib/rails/initializable.rb:30:in `run'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/railties-4.2.1/lib/rails/initializable.rb:55:in `block in run_initializers'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:226:in `block in tsort_each'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:427:in `each_strongly_connected_component_from'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:347:in `block in each_strongly_connected_component'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:345:in `each'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:345:in `call'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:345:in `each_strongly_connected_component'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:224:in `tsort_each'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/2.1.0/tsort.rb:205:in `tsort_each'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/railties-4.2.1/lib/rails/initializable.rb:54:in `run_initializers'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/gems/railties-4.2.1/lib/rails/application.rb:353:in `initialize!'
	from C:/Users/ashley/RubymineProjects/RJInvestments/config/environment.rb:5:in `<top (required)>'
	from C:/Users/ashley/RubymineProjects/RJInvestments/spec/rails_helper.rb:5:in `require'
	from C:/Users/ashley/RubymineProjects/RJInvestments/spec/rails_helper.rb:5:in `<top (required)>'
	from C:/Users/ashley/RubymineProjects/RJInvestments/spec/generators/rr_fixtures_bug_spec.rb:18:in `require'
	from C:/Users/ashley/RubymineProjects/RJInvestments/spec/generators/rr_fixtures_bug_spec.rb:18:in `<top (required)>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/configuration.rb:1332:in `load'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/configuration.rb:1332:in `block in load_spec_files'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/configuration.rb:1330:in `each'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/configuration.rb:1330:in `load_spec_files'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/runner.rb:102:in `setup'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/runner.rb:88:in `run'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/runner.rb:73:in `run'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/lib/rspec/core/runner.rb:41:in `invoke'
	from C:/rubys/ruby-2.1.5-x64-mingw32/lib/ruby/gems/2.1.0/bundler/gems/rspec-core-0697d3a9894f/exe/rspec:4:in `<top (required)>'
	from C:/rubys/ruby-2.1.5-x64-mingw32/bin/rspec:23:in `load'
	from C:/rubys/ruby-2.1.5-x64-mingw32/bin/rspec:23:in `<top (required)>'
	from -e:1:in `load'
	from -e:1:in `<main>'
```


